### PR TITLE
Preserve value of thread's system error

### DIFF
--- a/tracer/trace_arm64.c
+++ b/tracer/trace_arm64.c
@@ -1,6 +1,7 @@
 #include <capstone.h>
 #include <glib.h>
 #include <gum/gumstalker.h>
+#include <gum/gumprocess.h>
 #include <string.h>
 
 
@@ -473,6 +474,7 @@ static inline void print_trace_line_cmp(GumCpuContext *cpu_ctx, arm64_reg reg)
 static void
 on_insn(GumCpuContext *cpu_ctx, gpointer user_data)
 {
+        gint saved_system_error = gum_thread_get_system_error();
         const struct ctx_insn *ctx_insn = user_data;
         struct ctx_trace *last_ctx_trace = &state->last_ctx_trace;
         struct ctx_insn *last_ctx_insn = &last_ctx_trace->ctx_insn;
@@ -601,6 +603,7 @@ on_insn(GumCpuContext *cpu_ctx, gpointer user_data)
                 }
         #endif
 
+        gum_thread_set_system_error(saved_system_error);
 }
 
 
@@ -627,17 +630,20 @@ finalize(void)
 void
 flush(void)
 {
+        gint saved_system_error = gum_thread_get_system_error();
         gchar *trace = g_string_free(state->trace, FALSE);
 
         send(trace);
         g_free(trace);
         state->trace = g_string_new(NULL);
+        gum_thread_set_system_error(saved_system_error);
 }
 
 void
 transform(GumStalkerIterator *iterator, GumStalkerOutput *output,
           gpointer user_data)
 {
+        gint saved_system_error = gum_thread_get_system_error();
         cs_insn *insn;
         gsize insn_cnt = 0;
         gboolean enable_regs;
@@ -698,5 +704,6 @@ transform(GumStalkerIterator *iterator, GumStalkerOutput *output,
                 gum_stalker_iterator_keep(iterator);
                 ++insn_cnt;
         }
+        gum_thread_set_system_error(saved_system_error);
 }
 

--- a/tracer/trace_x64.c
+++ b/tracer/trace_x64.c
@@ -1,6 +1,7 @@
 #include <capstone.h>
 #include <glib.h>
 #include <gum/gumstalker.h>
+#include <gum/gumprocess.h>
 #include <string.h>
 
 
@@ -335,6 +336,7 @@ static inline void print_trace_line_cmp(GumCpuContext *cpu_ctx, x86_reg reg)
 static void
 on_insn(GumCpuContext *cpu_ctx, gpointer user_data)
 {
+        gint saved_system_error = gum_thread_get_system_error();
         const struct ctx_insn *ctx_insn = user_data;
         struct ctx_trace *last_ctx_trace = &state->last_ctx_trace;
         struct ctx_insn *last_ctx_insn = &last_ctx_trace->ctx_insn;
@@ -469,6 +471,7 @@ on_insn(GumCpuContext *cpu_ctx, gpointer user_data)
                 }
         #endif
 
+        gum_thread_set_system_error(saved_system_error);
 }
 
 
@@ -493,17 +496,20 @@ finalize(void)
 void
 flush(void)
 {
+        gint saved_system_error = gum_thread_get_system_error();
         gchar *trace = g_string_free(state->trace, FALSE);
 
         send(trace);
         g_free(trace);
         state->trace = g_string_new(NULL);
+        gum_thread_set_system_error(saved_system_error);
 }
 
 void
 transform(GumStalkerIterator *iterator, GumStalkerOutput *output,
           gpointer user_data)
 {
+        gint saved_system_error = gum_thread_get_system_error();
         cs_insn *insn;
         gsize insn_cnt = 0;
         gboolean enable_regs;
@@ -595,5 +601,6 @@ transform(GumStalkerIterator *iterator, GumStalkerOutput *output,
                 gum_stalker_iterator_keep(iterator);
                 ++insn_cnt;
         }
+	gum_thread_set_system_error(saved_system_error);
 }
 


### PR DESCRIPTION
This is so that tracing does not alter the system error value of the current thread, leading to incorrect program execution. Fixes #5 .