### PR TITLE
Revert "Preserve value of thread's system error"

### DIFF
--- a/tracer/trace_arm64.c
+++ b/tracer/trace_arm64.c
@@ -1,7 +1,6 @@
 #include <capstone.h>
 #include <glib.h>
 #include <gum/gumstalker.h>
-#include <gum/gumprocess.h>
 #include <string.h>
 
 
@@ -474,7 +473,6 @@ static inline void print_trace_line_cmp(GumCpuContext *cpu_ctx, arm64_reg reg)
 static void
 on_insn(GumCpuContext *cpu_ctx, gpointer user_data)
 {
-        gint saved_system_error = gum_thread_get_system_error();
         const struct ctx_insn *ctx_insn = user_data;
         struct ctx_trace *last_ctx_trace = &state->last_ctx_trace;
         struct ctx_insn *last_ctx_insn = &last_ctx_trace->ctx_insn;
@@ -603,7 +601,6 @@ on_insn(GumCpuContext *cpu_ctx, gpointer user_data)
                 }
         #endif
 
-        gum_thread_set_system_error(saved_system_error);
 }
 
 
@@ -630,20 +627,17 @@ finalize(void)
 void
 flush(void)
 {
-        gint saved_system_error = gum_thread_get_system_error();
         gchar *trace = g_string_free(state->trace, FALSE);
 
         send(trace);
         g_free(trace);
         state->trace = g_string_new(NULL);
-        gum_thread_set_system_error(saved_system_error);
 }
 
 void
 transform(GumStalkerIterator *iterator, GumStalkerOutput *output,
           gpointer user_data)
 {
-        gint saved_system_error = gum_thread_get_system_error();
         cs_insn *insn;
         gsize insn_cnt = 0;
         gboolean enable_regs;
@@ -704,6 +698,5 @@ transform(GumStalkerIterator *iterator, GumStalkerOutput *output,
                 gum_stalker_iterator_keep(iterator);
                 ++insn_cnt;
         }
-        gum_thread_set_system_error(saved_system_error);
 }
 

--- a/tracer/trace_x64.c
+++ b/tracer/trace_x64.c
@@ -1,7 +1,6 @@
 #include <capstone.h>
 #include <glib.h>
 #include <gum/gumstalker.h>
-#include <gum/gumprocess.h>
 #include <string.h>
 
 
@@ -336,7 +335,6 @@ static inline void print_trace_line_cmp(GumCpuContext *cpu_ctx, x86_reg reg)
 static void
 on_insn(GumCpuContext *cpu_ctx, gpointer user_data)
 {
-        gint saved_system_error = gum_thread_get_system_error();
         const struct ctx_insn *ctx_insn = user_data;
         struct ctx_trace *last_ctx_trace = &state->last_ctx_trace;
         struct ctx_insn *last_ctx_insn = &last_ctx_trace->ctx_insn;
@@ -471,7 +469,6 @@ on_insn(GumCpuContext *cpu_ctx, gpointer user_data)
                 }
         #endif
 
-        gum_thread_set_system_error(saved_system_error);
 }
 
 
@@ -496,20 +493,17 @@ finalize(void)
 void
 flush(void)
 {
-        gint saved_system_error = gum_thread_get_system_error();
         gchar *trace = g_string_free(state->trace, FALSE);
 
         send(trace);
         g_free(trace);
         state->trace = g_string_new(NULL);
-        gum_thread_set_system_error(saved_system_error);
 }
 
 void
 transform(GumStalkerIterator *iterator, GumStalkerOutput *output,
           gpointer user_data)
 {
-        gint saved_system_error = gum_thread_get_system_error();
         cs_insn *insn;
         gsize insn_cnt = 0;
         gboolean enable_regs;
@@ -604,6 +598,5 @@ transform(GumStalkerIterator *iterator, GumStalkerOutput *output,
                 gum_stalker_iterator_keep(iterator);
                 ++insn_cnt;
         }
-	gum_thread_set_system_error(saved_system_error);
 }
 


### PR DESCRIPTION
Reverts synacktiv/frinet#6

After additional testing, this change breaks Frinet (trying to trace the execute function of the /system/bin/sh binary on Android using `python3 trace.py -U attach 25199 sh 0x20050 -m` does not work anymore).